### PR TITLE
Add basic data models and tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -10,10 +10,10 @@
   - [x] Add automated testing & build pipeline (GitHub Actions, etc.).
 
 ## 2. Backend Development
-- [ ] Data Models
-  - [ ] `User` model with authentication fields.
-  - [ ] `Capsule` model: name, brand, roast level, flavor notes.
-  - [ ] `Rating` model: rating value, review text, timestamp, relation to User & Capsule.
+- [x] Data Models
+    - [x] `User` model with authentication fields.
+    - [x] `Capsule` model: name, brand, roast level, flavor notes.
+    - [x] `Rating` model: rating value, review text, timestamp, relation to User & Capsule.
 - [ ] User APIs
   - [ ] Register, login, edit profile endpoints.
 - [ ] Capsule APIs

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class User:
+    """Simple representation of an application user."""
+
+    username: str
+    email: str
+    password: str
+    id: int | None = None
+
+
+@dataclass
+class Capsule:
+    """Data about a coffee capsule entry."""
+
+    name: str
+    brand: str
+    roast_level: str
+    flavor_notes: str = ""
+    id: int | None = None
+
+
+@dataclass
+class Rating:
+    """User-provided rating for a given capsule."""
+
+    user: User
+    capsule: Capsule
+    value: int
+    review: str = ""
+    timestamp: datetime = field(default_factory=datetime.utcnow)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.models import Capsule, Rating, User
+
+
+def test_rating_links_user_and_capsule() -> None:
+    user = User(username="alice", email="alice@example.com", password="secret")
+    capsule = Capsule(
+        name="Espresso",
+        brand="CoffeeCo",
+        roast_level="medium",
+        flavor_notes="chocolate",
+    )
+    rating = Rating(user=user, capsule=capsule, value=4, review="Nice")
+
+    assert rating.user is user
+    assert rating.capsule is capsule
+    assert rating.value == 4
+    assert isinstance(rating.timestamp, datetime)


### PR DESCRIPTION
## Summary
- introduce simple dataclass models for users, capsules, and ratings
- add unit test ensuring rating links user and capsule with timestamp
- update task list to reflect completed data model work

## Testing
- `python -m flake8`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53c141538832c86126b429384c858